### PR TITLE
Fix get_ltp and get_ohlc

### DIFF
--- a/tradingapi_a/mconnect.py
+++ b/tradingapi_a/mconnect.py
@@ -281,7 +281,7 @@ class MConnect:
         '''
         ohlc_input: List of strings in exchange:trading symbol format
         '''
-        ohlc_details={"i":value for value in ohlc_input}
+        ohlc_details={"i":[value for value in ohlc_input]}
         try:
             #Using session request
             get_ohlc_data=self._get(
@@ -301,7 +301,7 @@ class MConnect:
         '''
         ltp_input: List of strings in exchange:trading symbol format
         '''
-        ltp_details={"i":value for value in ltp_input}
+        ltp_details={"i":[value for value in ltp_input]}
         try:
             #Using session request
             get_ltp_data=self._get(


### PR DESCRIPTION
get_ltp and get_ohlc expects pythonic list but this is just returning LTP of last stock.
This fix will populate list in place of last sock in list.